### PR TITLE
Update socket.js

### DIFF
--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -82,9 +82,9 @@ channel.on("presence_state", handlePresenceState)
 channel.on("presence_diff", handlePresenceDiff)
 
 // Handle messages that are sent to topics that don't have a client side representation
-socket.onMessage(({topic, event, payload}) => {
+socket.onMessage(({topic, event, payload, ref, join_ref}) => {
   if (event == "presence_diff" && /^user_presence:\d+$/.test(topic)) {
-    handlePresenceDiff(payload)
+    channel.trigger(event, payload, ref, join_ref)
   }
 })
 


### PR DESCRIPTION
This let's the default callbacks of the channel handle the presence updates and `onMessage` is just needed to push the event to the correct channel.

This is especially useful, as this does keep working even with the changes in phoenix 1.4